### PR TITLE
Fix Angular-HAL dependency on rfc6570

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
   ],
   "main": "angular-hal.js",
   "dependencies": {
-    "rfc6570": "~0.1.4",
+    "rfc6570": "0.1.4",
     "angular": "~1"
   },
   "devDependencies": {


### PR DESCRIPTION
Otherwise it gives:
`No tag found that was able to satisfy ~0.0.4. Available versions: 0.1.4`
