### PR TITLE
Only set headers if they weren't provided

### DIFF
--- a/angular-hal.js
+++ b/angular-hal.js
@@ -200,16 +200,15 @@ angular
 
         function callService(method, href, options, data) {
             if (!options) options = {};
+            if (!options.headers) options.headers = {};
+            if (!options.headers['Content-Type']) options.headers['Content-Type'] = 'application/json';
+            if (!options.headers.Accept) options.headers.Accept = 'application/hal+json,application/json';
 
             var resource = (
                 $http({
                     method: method,
                     url: options.transformUrl ? options.transformUrl(href) : href,
-                    headers: {
-                        'Authorization': options.authorization,
-                        'Content-Type': 'application/json',
-                        'Accept': 'application/hal+json,application/json'
-                    },
+                    headers: options.headers,
                     data: data
                 })
                 .then(function (res) {


### PR DESCRIPTION
Sometimes it's useful to use the default headers for the `$http` client in Angular. For instance, setting a default `Authorization` header is easier than specifying the header in every `halClient` request.
