### PR TITLE
Suport a custom Content-Type in requests.

### DIFF
--- a/angular-hal.js
+++ b/angular-hal.js
@@ -151,7 +151,14 @@ angular.module('angular-hal', [])
 
                     return callService(method, linkHref, options, data);
                 } else {
-                    return callService(method, linkHref, options, data);
+                    var opt = options;
+                    if (params && params['Content-Type']) {
+                        opt = angular.copy(options);
+                        if (!opt) opt = {};
+                        if (!opt.headers) opt.headers = {};
+                        opt.headers['Content-Type'] = params['Content-Type'];
+                    }
+                    return callService(method, linkHref, opt, data);
                 }
 
             } //callLink


### PR DESCRIPTION
Some operations using spring hateoas need to use Content-Type text/uri-list  to associate links between entities. Check this url:

http://blog.codeleak.pl/2014/10/exposing-spring-data-repositories-over-rest.html