### PR TITLE
expose Resource links as $links()

### DIFF
--- a/angular-hal.js
+++ b/angular-hal.js
@@ -39,6 +39,9 @@ angular.module('angular-hal', [])
 
             href = getSelfLink(href, data).href;
 
+            defineHiddenProperty(this, '$links', function () {
+                return links;
+            });
             defineHiddenProperty(this, '$href', function (rel, params) {
                 if (!(rel in links)) return null;
 


### PR DESCRIPTION
This is similar to need expressed in #23, but a client may want to see other properties of links in an array and not just the $href. [HAL links](https://tools.ietf.org/html/draft-kelly-json-hal-06#section-5) can have `name`, `title`, etc.