### PR TITLE
Fix problems when using ng-annotate

### DIFF
--- a/angular-hal.js
+++ b/angular-hal.js
@@ -9,6 +9,7 @@ angular.module('angular-hal', [])
     ) {
         var rfc6570 = $window.rfc6570;
 
+        /* @ngNoInject */
         this.$get = function (href, options) {
             return callService('GET', href, options);
         }; //get

--- a/bower.json
+++ b/bower.json
@@ -12,5 +12,6 @@
   },
   "devDependencies": {
     "angular-mocks": "*"
-  }
+  },
+  "version": "0.1.6"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-hal",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Hal client for angularjs",
   "repository": "git@github.com:elmerbulthuis/angular-hal.git",
   "author": "elmerbulthuis <elmerbulthuis@gmail.com>",


### PR DESCRIPTION
When using ng-annotate the $get function gets incorrectly replaced. This comment prevents ng-annotate from touching it.