### PR TITLE
Retrieve Meta Properties

### DIFF
--- a/angular-hal.js
+++ b/angular-hal.js
@@ -55,6 +55,26 @@ angular.module('angular-hal', [])
 
                 return hrefLink(links[rel], params);
             });
+            /**
+             * Fetch Meta Contents
+             * @param  {String} name the meta key name without the _ in front
+             * @return {mixed} the meta content
+             */
+            defineHiddenProperty(this, '$meta', function $meta(name) {
+                for(var i = 0; i < ignoreAttributePrefixes.length; i++) {
+                    var fullName = ignoreAttributePrefixes[i] + name;
+
+                    if(
+                        embeddedAttribute !== fullName &&
+                        linksAttribute !== fullName &&
+                        data.hasOwnProperty(fullName)
+                    ) {
+                        return data[fullName];
+                    }
+                }
+
+                return null;
+            });
             defineHiddenProperty(this, '$has', function (rel) {
                 return rel in links;
             });

--- a/test/halbuilder-test-resources.js
+++ b/test/halbuilder-test-resources.js
@@ -653,8 +653,6 @@ describe('halbuilder test resources', function () {
         $httpBackend.flush();
     });
 
-
-
     it('should resolve promise to error with invalid rel', function () {
         $httpBackend
             .expect('GET', 'https://example.com/api/customer/123456')
@@ -675,5 +673,27 @@ describe('halbuilder test resources', function () {
             );
 
         $httpBackend.flush();
+    });
+
+    it('should read meta from the resource except _embedded & _links', function () {
+      $httpBackend
+          .expect('GET', 'https://example.com/api/customer/123456')
+          .respond({
+              _links: {},
+              _embedded: {},
+              _someMeta: 'some value',
+              property: 'value',
+          });
+
+      var resource = halClient.$get("https://example.com/api/customer/123456", {}).then(function (resource) {
+          expect(resource).toEqual({
+            property: 'value',
+          });
+          expect(resource.$meta('links')).toEqual(null);
+          expect(resource.$meta('embedded')).toEqual(null);
+          expect(resource.$meta('someMeta')).toEqual('some value');
+      });
+
+      $httpBackend.flush();
     });
 });


### PR DESCRIPTION
Some Resource attributes are hidden as long their field begin with one of `ignoreAttributePrefixes`.

This Pull Request provides a way to retrieve those hidden values by using the function `$meta(name: string): mixed` on the Resource.