### PR TITLE
Browserify support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 [![Build Status](https://travis-ci.org/LuvDaSun/angular-hal.svg)](https://travis-ci.org/LuvDaSun/angular-hal)
 
+## 0.1.7
+
+### npm
+
+```shell
+npm install angular-hal
+```
+
+You can `require` angular-hal:
+
+```js
+angular.module('myMod', [
+  require('angular-hal'),
+]);
+```
 
 ## Help wanted!
 
@@ -61,4 +76,3 @@ stay tuned for more!
 If you wish to use this service in old (ie) browsers, you may need to use the following polyfills:
 - es5shim & es5sham, https://github.com/kriskowal/es5-shim, some parts of the service use es5 methods.
 - xhr-polyfill, https://github.com/LuvDaSun/xhr-polyfill, if you want to make cross domain requests in ie8 / ie9.
-

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+/* global require */
+/* global module */
+
+require('./angular-hal');
+module.exports = 'angular-hal';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-hal",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Hal client for angularjs",
   "repository": "git@github.com:elmerbulthuis/angular-hal.git",
   "author": "elmerbulthuis <elmerbulthuis@gmail.com>",


### PR DESCRIPTION
Hey people,

This change is to allow angular-hal to be loaded with browserify. The set of angular dependencies should probably be defined in package.json as well. But you may want to create a permanent branch. One supporting bower the other browserify. Otherwise running both bower and npm may result in two copies of the angular package within angular-hal.