### PR TITLE
Update main property to reference ES5 sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     }
   ],
   "license": "WTFPL",
-  "main": "src/index.js",
+  "main": "dist/angular-hal.js",
+  "module": "src/index.js",
   "dependencies": {
     "angular": ">=1.3",
     "content-type": "^1.0.1",


### PR DESCRIPTION
Also add a "module" property to reference ES2015 sources.

As the package currently stands, Webpack is unable to natively load `src/index.js` as it expects it to contain ES5+CommonJS sources.

See http://2ality.com/2017/04/setting-up-multi-platform-packages.html for best practices.